### PR TITLE
Add possibility for deferred scheduling

### DIFF
--- a/src/it/java/de/skuzzle/inject/async/ManuallyScheduledIT.java
+++ b/src/it/java/de/skuzzle/inject/async/ManuallyScheduledIT.java
@@ -1,0 +1,86 @@
+package de.skuzzle.inject.async;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+
+import de.skuzzle.inject.async.guice.GuiceAsync;
+import de.skuzzle.inject.async.guice.ScheduleFeature;
+import de.skuzzle.inject.async.schedule.ScheduleProperties;
+import de.skuzzle.inject.async.schedule.SchedulingService;
+import de.skuzzle.inject.async.schedule.annotation.Scheduled;
+import de.skuzzle.inject.async.schedule.annotation.SimpleTrigger;
+
+public class ManuallyScheduledIT {
+
+    private volatile CountDownLatch manualLatch = new CountDownLatch(2);
+    private volatile int counterManual;
+
+    @Inject
+    private SchedulingService schedulingService;
+
+    @Scheduled
+    @SimpleTrigger(100)
+    public void testManual() {
+        ++counterManual;
+        manualLatch.countDown();
+    }
+
+    @Test
+    public void testManuallyStart() throws Exception {
+        Guice.createInjector(new AbstractModule() {
+
+            @Override
+            protected void configure() {
+                final ScheduleProperties disableAutoScheduling = ScheduleProperties.defaultProperties()
+                        .disableAutoScheduling();
+
+                GuiceAsync.enableFeaturesFor(binder(),
+                        ScheduleFeature.withProperties(disableAutoScheduling));
+            }
+        }).injectMembers(this);
+
+        schedulingService.startManualScheduling();
+        manualLatch.await();
+        assertTrue(counterManual > 0);
+    }
+
+    @Test
+    public void testDoNotManuallyStart() throws Exception {
+        Guice.createInjector(new AbstractModule() {
+
+            @Override
+            protected void configure() {
+                final ScheduleProperties disableAutoScheduling = ScheduleProperties.defaultProperties()
+                        .disableAutoScheduling();
+
+                GuiceAsync.enableFeaturesFor(binder(),
+                        ScheduleFeature.withProperties(disableAutoScheduling));
+            }
+        }).injectMembers(this);
+
+        // this thing waits forever because scheduler is never started
+        final Thread waitForTimeout = new Thread(() -> {
+            try {
+                manualLatch.await();
+                // XXX: this would not fail the test because it occurs in wrong thread
+                fail();
+            } catch (final InterruptedException ignore) {
+            }
+        });
+
+        waitForTimeout.start();
+        Thread.sleep(1000);
+        waitForTimeout.interrupt();
+        assertEquals(0, counterManual);
+    }
+
+}

--- a/src/it/java/de/skuzzle/inject/async/ScheduledIT.java
+++ b/src/it/java/de/skuzzle/inject/async/ScheduledIT.java
@@ -20,6 +20,7 @@ import com.google.inject.Guice;
 import com.google.inject.Provides;
 import com.google.inject.name.Names;
 
+import de.skuzzle.inject.async.guice.DefaultFeatures;
 import de.skuzzle.inject.async.guice.GuiceAsync;
 import de.skuzzle.inject.async.schedule.ExceptionHandler;
 import de.skuzzle.inject.async.schedule.ExecutionContext;
@@ -158,7 +159,7 @@ public class ScheduledIT {
 
             @Override
             protected void configure() {
-                GuiceAsync.enableFor(binder());
+                GuiceAsync.enableFeaturesFor(binder(), DefaultFeatures.SCHEDULE);
 
                 bind(TestExceptionHandler.class).asEagerSingleton();
                 bind(TypeWithScheduledMethods.class).asEagerSingleton();

--- a/src/main/java/de/skuzzle/inject/async/guice/DefaultFeatures.java
+++ b/src/main/java/de/skuzzle/inject/async/guice/DefaultFeatures.java
@@ -1,7 +1,6 @@
 package de.skuzzle.inject.async.guice;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -12,8 +11,6 @@ import com.google.inject.Injector;
 
 import de.skuzzle.inject.async.methods.AsyncModule;
 import de.skuzzle.inject.async.methods.annotation.Async;
-import de.skuzzle.inject.async.schedule.ScheduleModule;
-import de.skuzzle.inject.async.schedule.ScheduleProperties;
 import de.skuzzle.inject.async.schedule.annotation.Scheduled;
 
 /**
@@ -26,6 +23,7 @@ import de.skuzzle.inject.async.schedule.annotation.Scheduled;
 public enum DefaultFeatures implements Feature {
     /** This feature enables handling of the {@link Async} annotation. */
     ASYNC {
+
         @Override
         public void installModuleTo(Binder binder, GuiceAsync principal) {
             binder.install(new AsyncModule(principal));
@@ -50,20 +48,12 @@ public enum DefaultFeatures implements Feature {
     SCHEDULE {
         @Override
         public void installModuleTo(Binder binder, GuiceAsync principal) {
-            binder.install(new ScheduleModule(
-                    principal,
-                    ScheduleProperties.defaultProperties()));
+            ScheduleFeature.DEFAULT.installModuleTo(binder, principal);
         }
 
         @Override
         public boolean cleanupExecutor(Injector injector, long timeout, TimeUnit timeUnit) {
-            final ScheduledExecutorService scheduler = injector.getInstance(Keys.DEFAULT_SCHEDULER_KEY);
-            if (!Shutdown.executor(scheduler, timeout, timeUnit)) {
-                LOG.warn("There are still active tasks lingering in default scheduler after shutdown. Wait time: {} {}",
-                        timeout, timeUnit);
-                return false;
-            }
-            return true;
+            return ScheduleFeature.DEFAULT.cleanupExecutor(injector, timeout, timeUnit);
         }
     };
 

--- a/src/main/java/de/skuzzle/inject/async/guice/DefaultFeatures.java
+++ b/src/main/java/de/skuzzle/inject/async/guice/DefaultFeatures.java
@@ -1,0 +1,72 @@
+package de.skuzzle.inject.async.guice;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+
+import de.skuzzle.inject.async.methods.AsyncModule;
+import de.skuzzle.inject.async.methods.annotation.Async;
+import de.skuzzle.inject.async.schedule.ScheduleModule;
+import de.skuzzle.inject.async.schedule.ScheduleProperties;
+import de.skuzzle.inject.async.schedule.annotation.Scheduled;
+
+/**
+ * Supported features that can be passed when initializing the async/scheduling subsystem.
+ * Each feature is self contained and has no dependence to other features being present.
+ *
+ * @author Simon Taddiken
+ * @since 2.0.0
+ */
+public enum DefaultFeatures implements Feature {
+    /** This feature enables handling of the {@link Async} annotation. */
+    ASYNC {
+        @Override
+        public void installModuleTo(Binder binder, GuiceAsync principal) {
+            binder.install(new AsyncModule(principal));
+        }
+
+        @Override
+        public boolean cleanupExecutor(Injector injector, long timeout, TimeUnit timeUnit) {
+            final ExecutorService executor = injector.getInstance(Keys.DEFAULT_EXECUTOR_KEY);
+            if (!Shutdown.executor(executor, timeout, timeUnit)) {
+                LOG.warn("There are still active tasks lingering in default executor after shutdown. Wait time: {} {}",
+                        timeout, timeUnit);
+                return false;
+            }
+            return true;
+        }
+    },
+    /**
+     * This feature enables handling of the {@link Scheduled} annotation. You may also use
+     * an instance of {@link ScheduleFeature} instead of this instance (but better do not
+     * provide both).
+     */
+    SCHEDULE {
+        @Override
+        public void installModuleTo(Binder binder, GuiceAsync principal) {
+            binder.install(new ScheduleModule(
+                    principal,
+                    ScheduleProperties.defaultProperties()));
+        }
+
+        @Override
+        public boolean cleanupExecutor(Injector injector, long timeout, TimeUnit timeUnit) {
+            final ScheduledExecutorService scheduler = injector.getInstance(Keys.DEFAULT_SCHEDULER_KEY);
+            if (!Shutdown.executor(scheduler, timeout, timeUnit)) {
+                LOG.warn("There are still active tasks lingering in default scheduler after shutdown. Wait time: {} {}",
+                        timeout, timeUnit);
+                return false;
+            }
+            return true;
+        }
+    };
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultFeatures.class);
+
+}

--- a/src/main/java/de/skuzzle/inject/async/guice/Feature.java
+++ b/src/main/java/de/skuzzle/inject/async/guice/Feature.java
@@ -1,17 +1,37 @@
 package de.skuzzle.inject.async.guice;
 
-import de.skuzzle.inject.async.methods.annotation.Async;
-import de.skuzzle.inject.async.schedule.annotation.Scheduled;
+import java.util.concurrent.TimeUnit;
+
+import com.google.inject.Binder;
+import com.google.inject.Injector;
 
 /**
- * Supported features that can be passed when initializing the async/scheduling subsystem.
- * Each feature is self contained and has no dependence to other features being present.
+ * A stand alone feature that can be passed to {@link GuiceAsync}. Use
+ * {@link DefaultFeatures} or the dedicated {@link ScheduleFeature} which allows
+ * customization.
  *
  * @author Simon Taddiken
+ * @since 2.0.0
  */
-public enum Feature {
-    /** This feature enables handling of the {@link Async} annotation. */
-    ASYNC,
-    /** This feature enables handling of the {@link Scheduled} annotation. */
-    SCHEDULE
+public interface Feature {
+
+    /**
+     * Installs the modules relevant to this feature to the given {@link Binder}.
+     *
+     * @param binder The binder to install any required modules to.
+     * @param principal The {@link GuiceAsync} instance guarding the modules from
+     *            unintended instantiation.
+     */
+    void installModuleTo(Binder binder, GuiceAsync principal);
+
+    /**
+     * Makes sure to shutdown this feature's executor when
+     * {@link GuiceAsyncService#shutdown(long, TimeUnit)} is being called.
+     *
+     * @param injector The injector.
+     * @param timeout The time to wait for an orderly shutdown.
+     * @param timeUnit Unit for the timeout parameter.
+     * @return Whether the executor orderly shutdown within given time.
+     */
+    boolean cleanupExecutor(Injector injector, long timeout, TimeUnit timeUnit);
 }

--- a/src/main/java/de/skuzzle/inject/async/guice/GuiceAsync.java
+++ b/src/main/java/de/skuzzle/inject/async/guice/GuiceAsync.java
@@ -32,8 +32,8 @@ import de.skuzzle.inject.async.schedule.annotation.Scheduled;
  * </pre>
  * <p>
  * You may choose to only enable scheduling OR async methods in case you do not need both.
- * See {@link #enableFeaturesFor(Binder, DefaultFeatures...)} and
- * {@link #createModuleWithFeatures(DefaultFeatures...)}.
+ * See {@link #enableFeaturesFor(Binder, Feature...)} and
+ * {@link #createModuleWithFeatures(Feature...)}.
  * <p>
  * Please see the JavaDoc of the {@link Async} and {@link Scheduled} annotation for
  * further usage information.

--- a/src/main/java/de/skuzzle/inject/async/guice/GuiceAsync.java
+++ b/src/main/java/de/skuzzle/inject/async/guice/GuiceAsync.java
@@ -2,22 +2,19 @@ package de.skuzzle.inject.async.guice;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.Set;
 import java.util.concurrent.ThreadFactory;
 
 import javax.inject.Singleton;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.AbstractModule;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 
-import de.skuzzle.inject.async.methods.AsyncModule;
 import de.skuzzle.inject.async.methods.annotation.Async;
-import de.skuzzle.inject.async.schedule.ScheduleModule;
 import de.skuzzle.inject.async.schedule.annotation.Scheduled;
 
 /**
@@ -35,8 +32,8 @@ import de.skuzzle.inject.async.schedule.annotation.Scheduled;
  * </pre>
  * <p>
  * You may choose to only enable scheduling OR async methods in case you do not need both.
- * See {@link #enableFeaturesFor(Binder, Feature...)} and
- * {@link #createModuleWithFeatures(Feature...)}.
+ * See {@link #enableFeaturesFor(Binder, DefaultFeatures...)} and
+ * {@link #createModuleWithFeatures(DefaultFeatures...)}.
  * <p>
  * Please see the JavaDoc of the {@link Async} and {@link Scheduled} annotation for
  * further usage information.
@@ -58,15 +55,17 @@ public final class GuiceAsync {
      * @param binder The binder to register with.
      */
     public static void enableFor(Binder binder) {
-        enableFeaturesFor(binder, Feature.ASYNC, Feature.SCHEDULE);
+        enableFeaturesFor(binder, DefaultFeatures.ASYNC, DefaultFeatures.SCHEDULE);
     }
 
     /**
-     * Enable support for the given {@link Feature features}. Allows to separately enable
-     * support for async or scheduled.
+     * Enable support for the given {@link DefaultFeatures features}. Allows to separately
+     * enable support for async or scheduled.
      *
      * @param binder The binder to register with.
      * @param features The features to enable.
+     * @since 2.0.0
+     * @see DefaultFeatures
      */
     public static void enableFeaturesFor(Binder binder, Feature... features) {
         checkArgument(binder != null, "binder must not be null");
@@ -81,44 +80,36 @@ public final class GuiceAsync {
      * @since 0.2.0
      */
     public static Module createModule() {
-        return createModuleWithFeatures(Feature.ASYNC, Feature.SCHEDULE);
+        return createModuleWithFeatures(DefaultFeatures.ASYNC, DefaultFeatures.SCHEDULE);
     }
 
     /**
-     * Creates a module taht can be used to enable the given features.
+     * Creates a module that can be used to enable the given features.
      *
      * @param features The features to enable.
      * @return The module.
+     * @since 2.0.0
      */
     public static Module createModuleWithFeatures(Feature... features) {
         final GuiceAsync principal = new GuiceAsync();
-        final EnumSet<Feature> featureSet = EnumSet.copyOf(Arrays.asList(features));
+        final Set<Feature> featureSet = ImmutableSet.copyOf(features);
         return new GuiceAsyncModule(principal, featureSet);
     }
 
     private static final class GuiceAsyncModule extends AbstractModule {
 
         private final GuiceAsync principal;
-        private final Set<Feature> features;
+        private final Set<Feature> enabledFeatures;
 
         public GuiceAsyncModule(GuiceAsync principal, Set<Feature> features) {
             checkArgument(!features.isEmpty(), "Set of features must not be empty");
             this.principal = principal;
-            this.features = features;
-        }
-
-        private boolean hasFeature(Feature feature) {
-            return features.contains(feature);
+            this.enabledFeatures = features;
         }
 
         @Override
         protected void configure() {
-            if (hasFeature(Feature.ASYNC)) {
-                install(new AsyncModule(principal));
-            }
-            if (hasFeature(Feature.SCHEDULE)) {
-                install(new ScheduleModule(principal));
-            }
+            enabledFeatures.forEach(feature -> feature.installModuleTo(binder(), principal));
             bind(GuiceAsyncService.class).to(GuiceAsyncServiceImpl.class).in(Singleton.class);
         }
 
@@ -126,7 +117,7 @@ public final class GuiceAsync {
         @Singleton
         @DefaultBinding
         Set<Feature> provideFeatures() {
-            return features;
+            return enabledFeatures;
         }
 
         @Provides

--- a/src/main/java/de/skuzzle/inject/async/guice/GuiceAsyncServiceImpl.java
+++ b/src/main/java/de/skuzzle/inject/async/guice/GuiceAsyncServiceImpl.java
@@ -1,20 +1,13 @@
 package de.skuzzle.inject.async.guice;
 
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.inject.Injector;
 
 class GuiceAsyncServiceImpl implements GuiceAsyncService {
-
-    private static final Logger LOG = LoggerFactory.getLogger(GuiceAsyncServiceImpl.class);
 
     private final Injector injector;
     private final Set<Feature> features;
@@ -27,40 +20,9 @@ class GuiceAsyncServiceImpl implements GuiceAsyncService {
 
     @Override
     public boolean shutdown(long timeout, TimeUnit timeUnit) {
-        boolean result = true;
-
-        if (features.contains(Feature.ASYNC)) {
-            final ExecutorService executor = injector.getInstance(Keys.DEFAULT_EXECUTOR_KEY);
-            if (!shutdownExecutor(executor, timeout, timeUnit)) {
-                LOG.warn("There are still active tasks lingering in default executor after shutdown. Wait time: {} {}",
-                        timeout, timeUnit);
-                result = false;
-            }
-        }
-        if (features.contains(Feature.SCHEDULE)) {
-            final ScheduledExecutorService scheduler = injector.getInstance(Keys.DEFAULT_SCHEDULER_KEY);
-            if (!shutdownExecutor(scheduler, timeout, timeUnit)) {
-                LOG.warn("There are still active tasks lingering in default scheduler after shutdown. Wait time: {} {}",
-                        timeout, timeUnit);
-                result = false;
-            }
-        }
-        return result;
-    }
-
-    private boolean shutdownExecutor(ExecutorService executor, long timeout, TimeUnit timeUnit) {
-        LOG.debug("Shutting down guice-async default executor instance {}", executor);
-        executor.shutdownNow();
-
-        try {
-            return executor.awaitTermination(timeout, timeUnit);
-        } catch (final InterruptedException e) {
-            final Thread currentThread = Thread.currentThread();
-            LOG.error("Thread {} interrupted while waiting to shutdown guice-async default executor",
-                    currentThread.getName(), e);
-            Thread.currentThread().interrupt();
-            return false;
-        }
+        return features.stream()
+                .map(feature -> feature.cleanupExecutor(injector, timeout, timeUnit))
+                .reduce(Boolean.TRUE, Boolean::logicalAnd);
     }
 
 }

--- a/src/main/java/de/skuzzle/inject/async/guice/Keys.java
+++ b/src/main/java/de/skuzzle/inject/async/guice/Keys.java
@@ -95,8 +95,7 @@ public final class Keys {
             boolean typeGiven) {
 
         final Errors errors = new Errors(method);
-        final Annotation bindingAnnotation = Annotations.findBindingAnnotation(errors,
-                method, method.getAnnotations());
+        final Annotation bindingAnnotation = Annotations.findBindingAnnotation(errors, method, method.getAnnotations());
         errors.throwConfigurationExceptionIfErrorsExist();
         final Key<?> key;
         if (bindingAnnotation == null && typeGiven) {

--- a/src/main/java/de/skuzzle/inject/async/guice/ScheduleFeature.java
+++ b/src/main/java/de/skuzzle/inject/async/guice/ScheduleFeature.java
@@ -1,0 +1,62 @@
+package de.skuzzle.inject.async.guice;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+
+import de.skuzzle.inject.async.schedule.ScheduleModule;
+import de.skuzzle.inject.async.schedule.ScheduleProperties;
+
+/**
+ * Specialized {@link Feature} that allows customization of the scheduling behavior by
+ * providing a custom instance of {@link ScheduleProperties}.
+ * <p>
+ *
+ * @author Simon Taddiken
+ * @since 2.0.0
+ * @see DefaultFeatures#SCHEDULE
+ */
+public class ScheduleFeature implements Feature {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ScheduleFeature.class);
+
+    private final ScheduleProperties scheduleProperties;
+
+    private ScheduleFeature(ScheduleProperties scheduleProperties) {
+        Preconditions.checkArgument(scheduleProperties != null, "scheduleProperties must not be null");
+        this.scheduleProperties = scheduleProperties;
+    }
+
+    /**
+     * Creates the feature and uses the given {@link ScheduleProperties}.
+     *
+     * @param scheduleProperties The properties.
+     * @return The Feature instance that can be passed to {@link GuiceAsync} during
+     *         initialization.
+     */
+    public static ScheduleFeature withProperties(ScheduleProperties scheduleProperties) {
+        return new ScheduleFeature(scheduleProperties);
+    }
+
+    @Override
+    public void installModuleTo(Binder binder, GuiceAsync principal) {
+        binder.install(new ScheduleModule(principal, scheduleProperties));
+    }
+
+    @Override
+    public boolean cleanupExecutor(Injector injector, long timeout, TimeUnit timeUnit) {
+        final ScheduledExecutorService scheduler = injector.getInstance(Keys.DEFAULT_SCHEDULER_KEY);
+        if (!Shutdown.executor(scheduler, timeout, timeUnit)) {
+            LOG.warn("There are still active tasks lingering in default scheduler after shutdown. Wait time: {} {}",
+                    timeout, timeUnit);
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/skuzzle/inject/async/guice/ScheduleFeature.java
+++ b/src/main/java/de/skuzzle/inject/async/guice/ScheduleFeature.java
@@ -26,6 +26,9 @@ public class ScheduleFeature implements Feature {
 
     private static final Logger LOG = LoggerFactory.getLogger(ScheduleFeature.class);
 
+    public static final ScheduleFeature DEFAULT = ScheduleFeature
+            .withProperties(ScheduleProperties.defaultProperties());
+
     private final ScheduleProperties scheduleProperties;
 
     private ScheduleFeature(ScheduleProperties scheduleProperties) {

--- a/src/main/java/de/skuzzle/inject/async/guice/ScheduleFeature.java
+++ b/src/main/java/de/skuzzle/inject/async/guice/ScheduleFeature.java
@@ -26,6 +26,10 @@ public class ScheduleFeature implements Feature {
 
     private static final Logger LOG = LoggerFactory.getLogger(ScheduleFeature.class);
 
+    /**
+     * The default instance. Enables the same behavior as
+     * {@link DefaultFeatures#SCHEDULE}.
+     */
     public static final ScheduleFeature DEFAULT = ScheduleFeature
             .withProperties(ScheduleProperties.defaultProperties());
 

--- a/src/main/java/de/skuzzle/inject/async/guice/Shutdown.java
+++ b/src/main/java/de/skuzzle/inject/async/guice/Shutdown.java
@@ -1,0 +1,27 @@
+package de.skuzzle.inject.async.guice;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class Shutdown {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Shutdown.class);
+
+    static boolean executor(ExecutorService executor, long timeout, TimeUnit timeUnit) {
+        LOG.debug("Shutting down guice-async default executor instance {}", executor);
+        executor.shutdownNow();
+
+        try {
+            return executor.awaitTermination(timeout, timeUnit);
+        } catch (final InterruptedException e) {
+            final Thread currentThread = Thread.currentThread();
+            LOG.error("Thread {} interrupted while waiting to shutdown guice-async default executor",
+                    currentThread.getName(), e);
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+}

--- a/src/main/java/de/skuzzle/inject/async/schedule/ManualStartTriggerStrategy.java
+++ b/src/main/java/de/skuzzle/inject/async/schedule/ManualStartTriggerStrategy.java
@@ -1,0 +1,5 @@
+package de.skuzzle.inject.async.schedule;
+
+public class ManualStartTriggerStrategy {
+
+}

--- a/src/main/java/de/skuzzle/inject/async/schedule/ManualStartTriggerStrategy.java
+++ b/src/main/java/de/skuzzle/inject/async/schedule/ManualStartTriggerStrategy.java
@@ -1,5 +1,0 @@
-package de.skuzzle.inject.async.schedule;
-
-public class ManualStartTriggerStrategy {
-
-}

--- a/src/main/java/de/skuzzle/inject/async/schedule/ScheduleModule.java
+++ b/src/main/java/de/skuzzle/inject/async/schedule/ScheduleModule.java
@@ -29,16 +29,21 @@ import de.skuzzle.inject.proxy.ScopedProxyBinder;
  */
 public final class ScheduleModule extends AbstractModule {
 
+    private final ScheduleProperties scheduleProperties;
+
     /**
      * This constructor is only allowed to be called from within the {@link GuiceAsync}
      * class.
      *
      * @param principal Restricts construction, not allowed to be null.
      */
-    public ScheduleModule(GuiceAsync principal) {
+    public ScheduleModule(GuiceAsync principal, ScheduleProperties scheduleProperties) {
         checkArgument(principal != null,
                 "instantiating this module is not allowed. Use the class "
                         + "GuiceAsync to enable asynchronous method support.");
+
+        checkArgument(scheduleProperties != null, "scheduleProperties must not be null");
+        this.scheduleProperties = scheduleProperties;
     }
 
     @Override
@@ -48,19 +53,21 @@ public final class ScheduleModule extends AbstractModule {
                 .in(Singleton.class);
 
         final SchedulingService schedulingService = new SchedulingServiceImpl(
+                scheduleProperties,
                 getProvider(Injector.class),
                 getProvider(TriggerStrategyRegistry.class));
+        bind(SchedulingService.class).toInstance(schedulingService);
 
         final TypeListener scheduleListener = new SchedulerTypeListener(schedulingService);
-        bind(SchedulingService.class).toInstance(schedulingService);
         requestInjection(scheduleListener);
         bindListener(Matchers.any(), scheduleListener);
 
+        // Execution scope
         final Provider<Map<String, Object>> executionMap = () -> ScheduledContextHolder
                 .getContext().getExecution().getProperties();
-
         bindScope(ExecutionScope.class, MapBasedScope.withMapSupplier(executionMap));
 
+        // ScheduledScope
         final Provider<Map<String, Object>> scheduledMap = () -> ScheduledContextHolder
                 .getContext().getProperties();
         bindScope(ScheduledScope.class, MapBasedScope.withMapSupplier(scheduledMap));

--- a/src/main/java/de/skuzzle/inject/async/schedule/ScheduleModule.java
+++ b/src/main/java/de/skuzzle/inject/async/schedule/ScheduleModule.java
@@ -36,6 +36,8 @@ public final class ScheduleModule extends AbstractModule {
      * class.
      *
      * @param principal Restricts construction, not allowed to be null.
+     * @param scheduleProperties Additional settings to be passed to the scheduling
+     *            features.
      */
     public ScheduleModule(GuiceAsync principal, ScheduleProperties scheduleProperties) {
         checkArgument(principal != null,

--- a/src/main/java/de/skuzzle/inject/async/schedule/ScheduleProperties.java
+++ b/src/main/java/de/skuzzle/inject/async/schedule/ScheduleProperties.java
@@ -1,0 +1,47 @@
+package de.skuzzle.inject.async.schedule;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * @since 2.0.0
+ * @author Simon Taddiken
+ */
+public final class ScheduleProperties {
+
+    private boolean enableAutoScheduling = true;
+
+    private ScheduleProperties() {
+
+    }
+
+    /**
+     * Returns the default properties.
+     *
+     * @return A new instance with defaults set.
+     */
+    public static ScheduleProperties defaultProperties() {
+        return new ScheduleProperties();
+    }
+
+    public ScheduleProperties enableAutoScheduling() {
+        this.enableAutoScheduling = true;
+        return this;
+    }
+
+    /**
+     * Disables the behavior of automatic method scheduling. If automatic scheduling is
+     * disabled, methods are only actually be scheduled with their
+     * {@link ScheduledExecutorService} after manually calling
+     * {@link SchedulingService#startManualScheduling()}.
+     *
+     * @return This instance for method chaining.
+     */
+    public ScheduleProperties disableAutoScheduling() {
+        this.enableAutoScheduling = false;
+        return this;
+    }
+
+    boolean isAutoSchedulingEnabled() {
+        return enableAutoScheduling;
+    }
+}

--- a/src/main/java/de/skuzzle/inject/async/schedule/ScheduleProperties.java
+++ b/src/main/java/de/skuzzle/inject/async/schedule/ScheduleProperties.java
@@ -23,11 +23,6 @@ public final class ScheduleProperties {
         return new ScheduleProperties();
     }
 
-    public ScheduleProperties enableAutoScheduling() {
-        this.enableAutoScheduling = true;
-        return this;
-    }
-
     /**
      * Disables the behavior of automatic method scheduling. If automatic scheduling is
      * disabled, methods are only actually be scheduled with their

--- a/src/main/java/de/skuzzle/inject/async/schedule/ScheduledContext.java
+++ b/src/main/java/de/skuzzle/inject/async/schedule/ScheduledContext.java
@@ -95,7 +95,7 @@ public interface ScheduledContext {
      * {@link #cancel(boolean)} method. If no Future object is set by the strategy,
      * canceling will not be possible.
      *
-     * @param futureSupplier
+     * @param futureSupplier Supplies the future instance.
      */
     void updateFuture(Supplier<Future<?>> futureSupplier);
 

--- a/src/main/java/de/skuzzle/inject/async/schedule/SchedulerTypeListener.java
+++ b/src/main/java/de/skuzzle/inject/async/schedule/SchedulerTypeListener.java
@@ -8,6 +8,9 @@ import java.util.function.Consumer;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.inject.TypeLiteral;
 import com.google.inject.spi.InjectionListener;
 import com.google.inject.spi.TypeEncounter;
@@ -15,9 +18,10 @@ import com.google.inject.spi.TypeListener;
 
 class SchedulerTypeListener implements TypeListener {
 
+    private static final Logger LOG = LoggerFactory.getLogger(SchedulerTypeListener.class);
+
     // synchronized in case the injector is set up asynchronously
-    private List<Class<?>> scheduleStatics = Collections
-            .synchronizedList(new ArrayList<>());
+    private List<Class<?>> scheduleStatics = Collections.synchronizedList(new ArrayList<>());
     private volatile boolean injectorReady;
 
     private final SchedulingService schedulingService;
@@ -48,8 +52,10 @@ class SchedulerTypeListener implements TypeListener {
         // ready. In the first case, we collect the types for later handling in second
         // case we can schedule them immediately
         if (this.injectorReady) {
+            LOG.trace("Encountered type {} while Injector was ready", type);
             MethodVisitor.forEachStaticMethod(type, this.schedulingService::scheduleStaticMethod);
         } else {
+            LOG.trace("Encountered type {} while Injector was NOT ready", type);
             this.scheduleStatics.add(type);
         }
     }
@@ -59,9 +65,9 @@ class SchedulerTypeListener implements TypeListener {
 
             @Override
             public void afterInjection(I injectee) {
-                final Consumer<Method> action = method -> SchedulerTypeListener.this.schedulingService
-                        .scheduleMemberMethod(method, injectee);
-                MethodVisitor.forEachMemberMethod(injectee.getClass(), action);
+                final Consumer<Method> scheduleMemberMethod = method -> schedulingService.scheduleMemberMethod(method,
+                        injectee);
+                MethodVisitor.forEachMemberMethod(injectee.getClass(), scheduleMemberMethod);
             }
         });
     }

--- a/src/main/java/de/skuzzle/inject/async/schedule/SchedulingService.java
+++ b/src/main/java/de/skuzzle/inject/async/schedule/SchedulingService.java
@@ -2,6 +2,9 @@ package de.skuzzle.inject.async.schedule;
 
 import java.lang.reflect.Method;
 
+import com.google.inject.Injector;
+
+import de.skuzzle.inject.async.schedule.annotation.ManuallyStarted;
 import de.skuzzle.inject.async.schedule.annotation.Scheduled;
 
 /**
@@ -29,4 +32,13 @@ public interface SchedulingService {
      * @param method The method to schedule. Must be a static method.
      */
     void scheduleStaticMethod(Method method);
+
+    /**
+     * Schedules all encountered methods that are annotated with {@link ManuallyStarted}.
+     * This method should only be called once during the lifetime of your Guice
+     * {@link Injector}. Calling it multiple times will have no effect.
+     *
+     * @since 2.0.0
+     */
+    void startManualScheduling();
 }

--- a/src/main/java/de/skuzzle/inject/async/schedule/SchedulingServiceImpl.java
+++ b/src/main/java/de/skuzzle/inject/async/schedule/SchedulingServiceImpl.java
@@ -2,6 +2,8 @@ package de.skuzzle.inject.async.schedule;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.concurrent.ScheduledExecutorService;
 
 import javax.inject.Provider;
@@ -21,11 +23,13 @@ class SchedulingServiceImpl implements SchedulingService {
 
     private final Provider<Injector> injector;
     private final Provider<TriggerStrategyRegistry> registry;
+    private final Collection<ManuallyStarted> manuallyStarted;
 
     SchedulingServiceImpl(Provider<Injector> injector,
             Provider<TriggerStrategyRegistry> registry) {
         this.injector = injector;
         this.registry = registry;
+        this.manuallyStarted = new ArrayList<>();
     }
 
     @Override
@@ -36,6 +40,12 @@ class SchedulingServiceImpl implements SchedulingService {
     @Override
     public void scheduleStaticMethod(Method method) {
         scheduleMethod(method, null);
+    }
+
+    @Override
+    public void startManualScheduling() {
+        manuallyStarted.forEach(ManuallyStarted::scheduleNow);
+        manuallyStarted.clear();
     }
 
     private void scheduleMethod(Method method, Object self) {
@@ -58,7 +68,37 @@ class SchedulingServiceImpl implements SchedulingService {
         final ScheduledContextImpl context = new ScheduledContextImpl(method, self);
         final InjectedMethodInvocation invocation = InjectedMethodInvocation.forMethod(method, self, injector.get());
         final LockableRunnable runnable = Runnables.createLockedRunnableStack(invocation, context, handler);
-        strategy.schedule(context, scheduler, runnable);
+
+        if (mustStartManually(method)) {
+            LOG.debug("Method '{}' is marked to be scheduled manually", method);
+            this.manuallyStarted.add(new ManuallyStarted(context, scheduler, runnable, strategy));
+        } else {
+            strategy.schedule(context, scheduler, runnable);
+        }
+    }
+
+    private boolean mustStartManually(Method method) {
+        return method.isAnnotationPresent(de.skuzzle.inject.async.schedule.annotation.ManuallyStarted.class);
+    }
+
+    private static class ManuallyStarted {
+        private final ScheduledContext context;
+        private final ScheduledExecutorService scheduler;
+        private final LockableRunnable runnable;
+        private final TriggerStrategy strategy;
+
+        ManuallyStarted(ScheduledContext context, ScheduledExecutorService scheduler, LockableRunnable runnable,
+                TriggerStrategy strategy) {
+            this.context = context;
+            this.scheduler = scheduler;
+            this.runnable = runnable;
+            this.strategy = strategy;
+        }
+
+        public void scheduleNow() {
+            this.strategy.schedule(context, scheduler, runnable);
+        }
+
     }
 
 }

--- a/src/main/java/de/skuzzle/inject/async/schedule/SchedulingServiceImpl.java
+++ b/src/main/java/de/skuzzle/inject/async/schedule/SchedulingServiceImpl.java
@@ -46,8 +46,10 @@ class SchedulingServiceImpl implements SchedulingService {
 
     @Override
     public void startManualScheduling() {
-        manuallyStarted.forEach(ManuallyStarted::scheduleNow);
-        manuallyStarted.clear();
+        synchronized (manuallyStarted) {
+            manuallyStarted.forEach(ManuallyStarted::scheduleNow);
+            manuallyStarted.clear();
+        }
     }
 
     private void scheduleMethod(Method method, Object self) {

--- a/src/main/java/de/skuzzle/inject/async/schedule/SchedulingServiceImpl.java
+++ b/src/main/java/de/skuzzle/inject/async/schedule/SchedulingServiceImpl.java
@@ -21,12 +21,14 @@ class SchedulingServiceImpl implements SchedulingService {
 
     private static final Logger LOG = LoggerFactory.getLogger(SchedulingServiceImpl.class);
 
+    private final ScheduleProperties scheduleProperties;
     private final Provider<Injector> injector;
     private final Provider<TriggerStrategyRegistry> registry;
     private final Collection<ManuallyStarted> manuallyStarted;
 
-    SchedulingServiceImpl(Provider<Injector> injector,
+    SchedulingServiceImpl(ScheduleProperties scheduleProperties, Provider<Injector> injector,
             Provider<TriggerStrategyRegistry> registry) {
+        this.scheduleProperties = scheduleProperties;
         this.injector = injector;
         this.registry = registry;
         this.manuallyStarted = new ArrayList<>();
@@ -78,7 +80,8 @@ class SchedulingServiceImpl implements SchedulingService {
     }
 
     private boolean mustStartManually(Method method) {
-        return method.isAnnotationPresent(de.skuzzle.inject.async.schedule.annotation.ManuallyStarted.class);
+        return !this.scheduleProperties.isAutoSchedulingEnabled() ||
+                method.isAnnotationPresent(de.skuzzle.inject.async.schedule.annotation.ManuallyStarted.class);
     }
 
     private static class ManuallyStarted {

--- a/src/main/java/de/skuzzle/inject/async/schedule/annotation/ManuallyStarted.java
+++ b/src/main/java/de/skuzzle/inject/async/schedule/annotation/ManuallyStarted.java
@@ -18,6 +18,4 @@ import de.skuzzle.inject.async.schedule.SchedulingService;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface ManuallyStarted {
-
-}
+public @interface ManuallyStarted {}

--- a/src/main/java/de/skuzzle/inject/async/schedule/annotation/ManuallyStarted.java
+++ b/src/main/java/de/skuzzle/inject/async/schedule/annotation/ManuallyStarted.java
@@ -1,0 +1,23 @@
+package de.skuzzle.inject.async.schedule.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import de.skuzzle.inject.async.schedule.SchedulingService;
+
+/**
+ * Disables auto-scheduling of the annotated method. By default, if a method is annotated
+ * with {@link Scheduled}, it will be scheduled by the time its type/instance is
+ * encountered/created by the Guice framework. Using this annotation you can defer the
+ * actual scheduling until {@link SchedulingService#startManualScheduling()} is called.
+ *
+ * @author Simon Taddiken
+ * @since 2.0.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ManuallyStarted {
+
+}

--- a/src/test/java/de/skuzzle/inject/async/guice/GuiceAsyncServiceImplTest.java
+++ b/src/test/java/de/skuzzle/inject/async/guice/GuiceAsyncServiceImplTest.java
@@ -11,7 +11,7 @@ public class GuiceAsyncServiceImplTest {
 
     @Test
     public void testShutdownNotAllFeaturesEnabled() throws Exception {
-        final Injector injector = Guice.createInjector(GuiceAsync.createModuleWithFeatures(Feature.ASYNC));
+        final Injector injector = Guice.createInjector(GuiceAsync.createModuleWithFeatures(DefaultFeatures.ASYNC));
         final GuiceAsyncService asyncService = injector.getInstance(GuiceAsyncService.class);
         asyncService.shutdown(1, TimeUnit.SECONDS);
     }

--- a/src/test/java/de/skuzzle/inject/async/schedule/trigger/CronTriggerTest.java
+++ b/src/test/java/de/skuzzle/inject/async/schedule/trigger/CronTriggerTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import com.google.inject.Guice;
 
-import de.skuzzle.inject.async.guice.Feature;
+import de.skuzzle.inject.async.guice.DefaultFeatures;
 import de.skuzzle.inject.async.guice.GuiceAsync;
 import de.skuzzle.inject.async.schedule.ScheduledContext;
 import de.skuzzle.inject.async.schedule.annotation.CronTrigger;
@@ -29,7 +29,7 @@ public class CronTriggerTest {
             }
         };
 
-        Guice.createInjector(GuiceAsync.createModuleWithFeatures(Feature.SCHEDULE), methods);
+        Guice.createInjector(GuiceAsync.createModuleWithFeatures(DefaultFeatures.SCHEDULE), methods);
         methods.waitFor(methods.throwingException);
         methods.exceptionHandler.assertExceptionThrown(RuntimeException.class);
     }
@@ -45,7 +45,7 @@ public class CronTriggerTest {
             }
         };
 
-        Guice.createInjector(GuiceAsync.createModuleWithFeatures(Feature.SCHEDULE), methods);
+        Guice.createInjector(GuiceAsync.createModuleWithFeatures(DefaultFeatures.SCHEDULE), methods);
         methods.waitFor(methods.threeTimes);
     }
 
@@ -60,7 +60,7 @@ public class CronTriggerTest {
             }
         };
 
-        Guice.createInjector(GuiceAsync.createModuleWithFeatures(Feature.SCHEDULE), methods);
+        Guice.createInjector(GuiceAsync.createModuleWithFeatures(DefaultFeatures.SCHEDULE), methods);
         // because the second count down should never happen
         methods.expectTimeoutFor(methods.cancel);
     }

--- a/src/test/java/de/skuzzle/inject/async/schedule/trigger/DelayTriggerTest.java
+++ b/src/test/java/de/skuzzle/inject/async/schedule/trigger/DelayTriggerTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import com.google.inject.Guice;
 
-import de.skuzzle.inject.async.guice.Feature;
+import de.skuzzle.inject.async.guice.DefaultFeatures;
 import de.skuzzle.inject.async.guice.GuiceAsync;
 import de.skuzzle.inject.async.schedule.annotation.DelayedTrigger;
 import de.skuzzle.inject.async.schedule.annotation.OnError;
@@ -28,7 +28,7 @@ public class DelayTriggerTest {
             }
         };
 
-        Guice.createInjector(GuiceAsync.createModuleWithFeatures(Feature.SCHEDULE), methods);
+        Guice.createInjector(GuiceAsync.createModuleWithFeatures(DefaultFeatures.SCHEDULE), methods);
         methods.waitFor(methods.throwingException);
         methods.exceptionHandler.assertExceptionThrown(RuntimeException.class);
     }
@@ -44,7 +44,7 @@ public class DelayTriggerTest {
             }
         };
 
-        Guice.createInjector(GuiceAsync.createModuleWithFeatures(Feature.SCHEDULE), methods);
+        Guice.createInjector(GuiceAsync.createModuleWithFeatures(DefaultFeatures.SCHEDULE), methods);
         methods.expectTimeoutFor(methods.threeTimes);
     }
 

--- a/src/test/java/de/skuzzle/inject/async/schedule/trigger/SimpleTriggerTest.java
+++ b/src/test/java/de/skuzzle/inject/async/schedule/trigger/SimpleTriggerTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import com.google.inject.Guice;
 
-import de.skuzzle.inject.async.guice.Feature;
+import de.skuzzle.inject.async.guice.DefaultFeatures;
 import de.skuzzle.inject.async.guice.GuiceAsync;
 import de.skuzzle.inject.async.schedule.ScheduledContext;
 import de.skuzzle.inject.async.schedule.annotation.OnError;
@@ -29,7 +29,7 @@ public class SimpleTriggerTest {
             }
         };
 
-        Guice.createInjector(GuiceAsync.createModuleWithFeatures(Feature.SCHEDULE), methods);
+        Guice.createInjector(GuiceAsync.createModuleWithFeatures(DefaultFeatures.SCHEDULE), methods);
         methods.waitFor(methods.throwingException);
         methods.exceptionHandler.assertExceptionThrown(RuntimeException.class);
     }
@@ -45,7 +45,7 @@ public class SimpleTriggerTest {
             }
         };
 
-        Guice.createInjector(GuiceAsync.createModuleWithFeatures(Feature.SCHEDULE), methods);
+        Guice.createInjector(GuiceAsync.createModuleWithFeatures(DefaultFeatures.SCHEDULE), methods);
         methods.waitFor(methods.threeTimes);
     }
 
@@ -60,7 +60,7 @@ public class SimpleTriggerTest {
             }
         };
 
-        Guice.createInjector(GuiceAsync.createModuleWithFeatures(Feature.SCHEDULE), methods);
+        Guice.createInjector(GuiceAsync.createModuleWithFeatures(DefaultFeatures.SCHEDULE), methods);
         // because the second count down should never happen
         methods.expectTimeoutFor(methods.cancel);
     }


### PR DESCRIPTION
This feature is a first attempt to solve the problems described in #7:
When methods are auto-scheduled, the Executor and ThreadPools are
eagerly set up while the Injector is being created. If an error occurs
during Injector creation those Threads are left dangling in nirvana and
might prevent the JVM from properly shutting down.

Using @ManuallyStarted now marks a scheduled method as deferred. It will
first be scheduled by the time SchedulingService.startManualScheduling()
is called.